### PR TITLE
modified gen_uhd_usrp_blocks.py

### DIFF
--- a/gr-uhd/grc/gen_uhd_usrp_blocks.py
+++ b/gr-uhd/grc/gen_uhd_usrp_blocks.py
@@ -88,12 +88,8 @@ self.\$(id).set_lo_export_enabled(\$lo_export$(n), uhd.ALL_LOS, $n)
     \#if \$lo_source$(n)() and not \$hide_lo_controls()
 self.\$(id).set_lo_source(\$lo_source$(n), uhd.ALL_LOS, $n)
 	\#end if
-	\#if \$dc_offs_enb$(n)()
 self.\$(id).set_auto_dc_offset(\$dc_offs_enb$(n), $n)
-	\#end if
-	\#if \$iq_imbal_enb$(n)()
 self.\$(id).set_auto_iq_balance(\$iq_imbal_enb$(n), $n)
-	\#end if
 #end if
 \#end if
 #end for
@@ -600,7 +596,7 @@ PARAMS_TMPL = """	<param>
 	<param>
 		<name>Ch$(n): Enable DC Offset Correction</name>
 		<key>dc_offs_enb$(n)</key>
-		<value>""</value>
+		<value>True</value>
 		<type>raw</type>
 		<hide>
 			\#if not \$nchan() > $n
@@ -614,7 +610,7 @@ PARAMS_TMPL = """	<param>
 	<param>
 		<name>Ch$(n): Enable IQ Imbalance Correction</name>
 		<key>iq_imbal_enb$(n)</key>
-		<value>""</value>
+		<value>True</value>
 		<type>raw</type>
 		<hide>
 			\#if not \$nchan() > $n


### PR DESCRIPTION
Removed the if check around self.$(id).set_auto_dc_offset($dc_offs_enb$(n), $n) and self.$(id).set_auto_iq_balance($iq_imbal_enb$(n), $n). In the FE corrections tab, if False was entered, the if check would be set to false and prevent the DC filter from being turned off. Now the FE correction tab can be used to turn dc_offset and IQ_balance on or off (On is the default value).

this solves the issue from this link
#1236